### PR TITLE
chore: migrate to speakeasy workflows

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -1,33 +1,26 @@
 name: Generate
 permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
+    checks: write
+    contents: write
+    pull-requests: write
+    statuses: write
 "on":
-  workflow_dispatch:
-    inputs:
-      force:
-        description: Force generation of SDKs
-        type: boolean
-        default: false
-  schedule:
-    - cron: 0 0 * * *
+    workflow_dispatch:
+        inputs:
+            force:
+                description: Force generation of SDKs
+                type: boolean
+                default: false
+    schedule:
+        - cron: 0 0 * * *
 jobs:
-  generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14
-    with:
-      force: ${{ github.event.inputs.force }}
-      languages: |
-        - unity
-      mode: pr
-      openapi_doc_auth_header: x-api-key
-      openapi_docs: |
-        - https://hathora.dev/swagger.json
-      speakeasy_version: latest
-      overlay_docs: |
-        - ./overlay.yaml
-    secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      openapi_doc_auth_token: ${{ secrets.SPEAKEASY_PROD_API_KEY }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_PROD_API_KEY }}
+    generate:
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+        with:
+            force: ${{ github.event.inputs.force }}
+            mode: pr
+            speakeasy_version: latest
+        secrets:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            openapi_doc_auth_token: ${{ secrets.SPEAKEASY_PROD_API_KEY }}
+            speakeasy_api_key: ${{ secrets.SPEAKEASY_PROD_API_KEY }}

--- a/.github/workflows/speakeasy_sdk_publish.yml
+++ b/.github/workflows/speakeasy_sdk_publish.yml
@@ -1,16 +1,14 @@
 name: Publish
 "on":
-  push:
-    branches:
-      - main
-    paths:
-      - RELEASES.md
+    push:
+        branches:
+            - main
+        paths:
+            - RELEASES.md
 jobs:
-  publish:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v14
-    with:
-      create_release: true
-    secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      openapi_doc_auth_token: ${{ secrets.SPEAKEASY_PROD_API_KEY }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_PROD_API_KEY }}
+    publish:
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15
+        secrets:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            openapi_doc_auth_token: ${{ secrets.SPEAKEASY_PROD_API_KEY }}
+            speakeasy_api_key: ${{ secrets.SPEAKEASY_PROD_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -4,6 +4,8 @@ sources:
     my-source:
         inputs:
             - location: https://hathora.dev/swagger.json
+        overlays:
+            - location: overlay.yaml
 targets:
     cloud-sdk-unity:
         target: unity

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,11 @@
+workflowVersion: 1.0.0
+speakeasyVersion: latest
+sources:
+    my-source:
+        inputs:
+            - location: https://hathora.dev/swagger.json
+targets:
+    cloud-sdk-unity:
+        target: unity
+        source: my-source
+        output: .


### PR DESCRIPTION
This PR migrates this SDK to Speakeasy's new workflow file specification https://www.speakeasyapi.dev/docs/workflow-migration. speakeasy migrate was run to create this PR.

Benefits:
* Complete generation workflow is emulated locally now by checking out repo and running `speakeasy run`
* Opens up integrations with doc providers

![CleanShot 2024-04-18 at 18 15 23@2x](https://github.com/hathora/cloud-sdk-unity/assets/68016351/8dea36b6-8bd4-47b1-88c4-066ec1ff3b90)
